### PR TITLE
Add sdem

### DIFF
--- a/urbansim_defaults/datasources.py
+++ b/urbansim_defaults/datasources.py
@@ -14,6 +14,11 @@ warnings.filterwarnings('ignore', category=pd.io.pytables.PerformanceWarning)
 pd.options.mode.chained_assignment = None
 
 
+@orca.injectable('year')
+def year(iter_var):
+    return iter_var
+
+
 @orca.injectable('settings', cache=True)
 def settings():
     with open(os.path.join(misc.configs_dir(), "settings.yaml")) as f:

--- a/urbansim_defaults/models.py
+++ b/urbansim_defaults/models.py
@@ -198,7 +198,7 @@ def non_residential_developer(feasibility, jobs, buildings, parcels, year,
     summary.add_parcel_output(new_buildings)
 
 
-@orca.model("scheduled_development_events")
+@orca.step("scheduled_development_events")
 def scheduled_development_events(buildings, development_projects, summary, year):
     dps = development_projects.to_frame().query("year_built == %d" % year)
 

--- a/urbansim_defaults/models.py
+++ b/urbansim_defaults/models.py
@@ -197,11 +197,17 @@ def non_residential_developer(feasibility, jobs, buildings, parcels, year,
 
 
 @sim.model("scheduled_development_events")
-def scheduled_development_events(buildings, development_projects, year):
+def scheduled_development_events(buildings, development_projects, summary, year):
     dps = development_projects.to_frame().query("year_built == %d" % year)
-    utils.scheduled_development_events(buildings, dps,
+
+    if len(dps) == 0:
+        return
+
+    new_buildings = utils.scheduled_development_events(buildings, dps,
                                        remove_developed_buildings=True,
                                        unplace_agents=['households', 'jobs'])
+
+    summary.add_parcel_output(new_buildings)
 
 
 @sim.model("diagnostic_output")
@@ -232,6 +238,8 @@ def diagnostic_output(households, buildings, parcels, zones, year, summary):
     zones['average_income'] = households.groupby('zone_id').income.quantile()
     zones['household_size'] = households.groupby('zone_id').persons.quantile()
 
+    zones['building_count'] = buildings.\
+        query('general_type == "Residential"').groupby('zone_id').size()
     zones['residential_price'] = buildings.\
         query('general_type == "Residential"').groupby('zone_id').\
         residential_price.quantile()

--- a/urbansim_defaults/models.py
+++ b/urbansim_defaults/models.py
@@ -196,6 +196,14 @@ def non_residential_developer(feasibility, jobs, buildings, parcels, year,
     summary.add_parcel_output(new_buildings)
 
 
+@sim.model("scheduled_development_events")
+def scheduled_development_events(buildings, development_projects, year):
+    dps = development_projects.to_frame().query("year_built == %d" % year)
+    utils.scheduled_development_events(buildings, dps,
+                                       remove_developed_buildings=True,
+                                       unplace_agents=['households', 'jobs'])
+
+
 @sim.model("diagnostic_output")
 def diagnostic_output(households, buildings, parcels, zones, year, summary):
     households = households.to_frame()

--- a/urbansim_defaults/utils.py
+++ b/urbansim_defaults/utils.py
@@ -797,9 +797,9 @@ def run_developer(forms, agents, buildings, supply_fname, parcel_size,
 
     orca.add_table("buildings", all_buildings)
 
-    if "residential_units" in sim.list_tables() and residential:
+    if "residential_units" in orca.list_tables() and residential:
         # need to add units to the units table as well
-        old_units = sim.get_table("residential_units")
+        old_units = orca.get_table("residential_units")
         old_units = old_units.to_frame(old_units.local_columns)
         new_units = pd.DataFrame({
             "unit_residential_price": 0,
@@ -817,7 +817,7 @@ def run_developer(forms, agents, buildings, supply_fname, parcel_size,
         all_units = dev.merge(old_units, new_units)
         all_units.index.name = "unit_id"
 
-        sim.add_table("residential_units", all_units)
+        orca.add_table("residential_units", all_units)
 
         return ret_buildings
         # pondered returning ret_buildings, new_units but users can get_table
@@ -862,7 +862,7 @@ def scheduled_development_events(buildings, new_buildings,
     print "Res units after: {:,}".format(all_buildings.residential_units.sum())
     print "Non-res sqft after: {:,}".format(all_buildings.non_residential_sqft.sum())
 
-    sim.add_table("buildings", all_buildings)
+    orca.add_table("buildings", all_buildings)
     return new_buildings
 
 

--- a/urbansim_defaults/utils.py
+++ b/urbansim_defaults/utils.py
@@ -836,6 +836,8 @@ def scheduled_development_events(buildings, new_buildings,
 
     Parameters
     ----------
+    buildings : DataFrame wrapper
+        Just pass in the building dataframe wrapper
     new_buildings : DataFrame
         The new buildings to add to out buildings table.  They should have the same
         columns as the local columns in the buildings table.
@@ -843,17 +845,24 @@ def scheduled_development_events(buildings, new_buildings,
 
     print "Adding {:,} buildings as scheduled development events".format(
           len(new_buildings))
-
+    
     old_buildings = buildings.to_frame(buildings.local_columns)
     new_buildings = new_buildings[buildings.local_columns]
+    
+    print "Res units before: {:,}".format(old_buildings.residential_units.sum())
+    print "Non-res sqft before: {:,}".format(old_buildings.non_residential_sqft.sum())
 
     if remove_developed_buildings:
         old_buildings = \
             _remove_developed_buildings(old_buildings, new_buildings, unplace_agents)
 
     all_buildings = developer.Developer.merge(old_buildings, new_buildings)
+    
+    print "Res units after: {:,}".format(all_buildings.residential_units.sum())
+    print "Non-res sqft after: {:,}".format(all_buildings.non_residential_sqft.sum())
 
     sim.add_table("buildings", all_buildings)
+    return new_buildings
 
 
 class SimulationSummaryData(object):


### PR DESCRIPTION
Shouldn't be anything controversial here.  Adding scheduled_development_events model to utils, with proper comments for documentation, and a small wrapper to add an orca.step called scheduled_development_events.  Shouldn't affect anything that was here previously.  Moved "removing buildings" out into a function so it can be used in both the developer and scheduled development events.  Also adding "year" injectable to wrap `iter_var` with a more simulation-specific name.