### PR TITLE
fix the index that is returned by merge buildings

### DIFF
--- a/urbansim_defaults/utils.py
+++ b/urbansim_defaults/utils.py
@@ -820,7 +820,9 @@ def run_developer(forms, agents, buildings, supply_fname, parcel_size,
         old_buildings = \
             _remove_developed_buildings(old_buildings, new_buildings, unplace_agents)
 
-    all_buildings = dev.merge(old_buildings, new_buildings)
+    all_buildings, new_index = dev.merge(old_buildings, new_buildings,
+                                         return_index=True)
+    ret_buildings.index = new_index
 
     orca.add_table("buildings", all_buildings)
 


### PR DESCRIPTION
since we're changing the index of the buildings that get added to the buildings table, need to return it so the user knows what it has been set to